### PR TITLE
Examples - writing ppxs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ INSTALL_ARGS := $(if $(PREFIX),--prefix $(PREFIX),)
 EXAMPLE_DESCRIPTIONS := \
 	"example-building-ast:Demonstrates how to build AST" \
 	"example-destructuring-ast:Demonstrates how to destructure an AST" \
+	"example-context-free:Demonstrates how to use context free transformations" \
+	"example-global-transformation:Demonstrates how to use global transformations"
 
 .PHONY: help
 help: ## Print this help message

--- a/doc/example-writing-ppxs-context-free.mld
+++ b/doc/example-writing-ppxs-context-free.mld
@@ -1,0 +1,487 @@
+{0 Context-Free Transformations}
+
+{1:table-of-contents Table of Contents}
+
+- {{!section-description} Description}
+- {{!section-"types-of-context-free-transformations"} Types of Context-Free Transformations}
+- {{!section-"extenders"} Extenders}
+{ul {- {{!section-"example-1-a-simple-extender"} Example 1: A Simple Extender}}}
+{ul {- {{!section-"example-2-a-more-complex-extender-with-payload"} Example 2: A More Complex Extender with Payload}}}
+
+- {{!section-"derivers"} Derivers}
+{ul {- {{!section-"example-1-enum-deriver"} Example 1: Enum Deriver}}}
+{ul {- {{!section-"example-2-enum-deriver-with-args"} Example 2: Enum Deriver with args}}}
+
+{1:description Description}
+
+Context-free transformations allow you to read and modify code locally, without needing to consider the global context. In practice, this means that a portion of the Abstract Syntax Tree (AST) is provided to the transformation, and the transformation returns a new AST with the applied modifications.
+
+{1:types-of-context-free-transformations Types of Context-Free Transformations}
+
+There are two main types of context-free transformations:
+
+- {b Extenders}: These modify the extension node by generating new code.
+- {b Derivers}: These append code after the item without changing the original item.
+
+{1:extenders Extenders}
+📄 {{!page-driver.def_extenders} Doc}
+
+{%html:
+  <div style="border-left: 4px solid #0366d6; padding: 0.2em 1em;">
+    <strong>✏️ Note</strong>
+    <p style="margin-top: 0.5em; margin-bottom: 0;">Extenders work with extension nodes. If you have any doubts about attributes, please review the <a href="../../1%20-%20AST/README.md#ast_extension_node">AST Extension Node section</a>.</p>
+  </div>
+%}
+
+Extenders allow you to replace an extension node with new content. However, they do not have direct access to the surrounding code context, so they cannot modify the surrounding code.
+
+If an extender is broken or missing, the code will not compile. Therefore, it is important to ensure that the extender is correctly implemented.
+
+An extension node is a node in the AST that represents an extension point. For example, in the code [let x = [%foo]], [[%foo]] is an extension node.
+
+Let's look at some examples to understand how this works.
+
+With extenders, we need to:
+
+- {b Hook the extension.}
+- {b Transform the payload} (if there is one).
+- {b Create a new AST.}
+
+{2:example-1-a-simple-extender Example 1: A Simple Extender}
+{{:https://github.com/ocaml-ppx/ppxlib/tree/main/examples/2-Writing-PPXs/a%20-%20Context-Free/context_free.ml#L40-L49} 🔗 Sample Code}
+
+Consider the following code:
+
+{[
+let one = [%one]
+(* Output: let one = 1 *)
+]}
+
+Here, [[%one]] is replaced with the integer value [1]. This is a basic example of an extender transformation.
+
+{3 Steps to Implement This Extender}
+
+- {b Declare the extension name:}
+
+  {[
+  let extender_name = "one"
+  ]}
+
+- {b Define the extender extractor:}
+  Since there is no payload (additional data), we define the extractor as:
+
+  {[
+  let extender_extracter = Ast_pattern.(pstr nil)
+  ]}
+
+- {b Create the new AST:}
+  We define the expression that will replace [[%one]]:
+
+  {[
+  let expression ~loc = [%expr 1]
+  ]}
+
+  Alternatively, you can use:
+
+  {[
+  let expression ~loc = Ast_builder.Default.eint ~loc 1
+  ]}
+
+- {b Declare the extender and register it:}
+
+  {[
+  (* Define the expansion logic *)
+  let expand ~ctxt =
+    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+    expression ~loc
+
+  (* Define the extension *)
+  let extension =
+    Extension.V3.declare extender_name Extension.Context.expression
+      extender_extracter
+      expand
+
+  (* Register the extender *)
+  let rule = Ppxlib.Context_free.Rule.extension extension
+  let () = Driver.register_transformation ~rules:[ rule ] extender_name
+  ]}
+
+{2:example-2-a-more-complex-extender-with-payload Example 2: A More Complex Extender with Payload}
+{{:https://github.com/ocaml-ppx/ppxlib/tree/main/examples/2-Writing-PPXs/a%20-%20Context-Free/context_free.ml#L51-L76} 🔗 Sample Code}
+
+Let's look at a more complex example, where we replace [[%emoji "grin"]] with an emoji:
+
+{[
+let grin = [%emoji "grin"]
+(* Output: let grin = "😀" *)
+]}
+
+{3 Steps to Implement This Extender}
+
+- {b Declare the extension name and extractor:}
+  Here, the payload is a string (the alias of the emoji):
+
+  {[
+  let extender_name = "emoji"
+  let extender_extracter = Ast_pattern.(single_expr_payload (estring __))
+  ]}
+
+- {b Create the new AST:}  
+  We define the expression to replace the alias with the corresponding emoji:
+
+  {[
+  let expression ~loc ~emoji = [%expr [%e estring ~loc emoji]]
+  ]}
+
+- {b Define the expansion logic:}  
+  We need to map the alias to an emoji and return the appropriate AST. If the alias isn't found, we return an error:
+
+  {[
+  let emojis =
+    [
+      { emoji = "😀"; alias = "grin" };
+      { emoji = "😃"; alias = "smiley" };
+      { emoji = "😄"; alias = "smile" };
+    ]
+
+  let expand ~ctxt emoji_text =
+    let loc = Expansion_context.Extension.extension_point_loc ctxt in
+
+    let find_emoji_by_alias alias =
+      List.find_opt (fun emoji -> alias = emoji.alias) emojis
+    in
+
+    match find_emoji_by_alias emoji_text with
+    | Some value -> expression ~loc ~emoji:value.emoji
+    | None ->
+        let ext =
+          Location.error_extensionf ~loc "No emoji found for alias %s" emoji_text
+        in
+        Ast_builder.Default.pexp_extension ~loc ext
+  ]}
+
+- {b Declare the extender:}
+
+  {[
+  let extension =
+    Extension.V3.declare extender_name Extension.Context.expression
+      extender_extracter
+      expand
+  ]}
+
+{1:derivers Derivers}
+📄 {{!page-driver.def_derivers} Doc}
+
+{%html:
+  <div style="border-left: 4px solid #0366d6; padding: 0.2em 1em;">
+    <strong>✏️ Note</strong>
+    <p style="margin-top: 0.5em; margin-bottom: 0;">A deriver is a custom attribute provided by PPXlib. If you have any doubts about attributes, please review the AST Attributes section.</p>
+  </div>
+%}
+
+Derivers differ from extenders in that they append new code after an existing item rather than replacing parts of it. The new code can work in conjunction with the original item or independently, depending on the transformation needed. They are specified using the [[@@deriving]] attribute.
+
+A simple and common example of a deriver is the [enum] deriver:
+
+{[
+type t = A | B [@@deriving enum]
+(* Output:
+type t = A | B
+let to_string = function
+  | A -> "A"
+  | B -> "B"
+let from_string = function
+  | "A" -> A
+  | "B" -> B
+  | _ -> raise (Invalid_argument "Argument doesn't match t variants")
+*)
+]}
+
+In this example, the deriver [enum] automatically generates [to_string] and [from_string] functions for a variant type.
+
+Derivers are generally more complex to register than extenders, but PPXLib simplifies this with the [Deriving.add] function, which handles the registration. This function uses [Driver.register_transformation] under the hood.
+
+It can be attached to various types of structures and signatures. For instance, to create a deriver for a type declaration, you would use the [~str_type_decl] argument. If the deriver should also work for signature items, you would use the [~sig_type_decl] argument.
+
+The full list of arguments for [Deriving.add] can be found in the {%html:<a href="https://ocaml-ppx.github.io/ppxlib/ppxlib/Ppxlib/Deriving/index.html#val-add">documentation</a>%}.
+
+{2:example-1-enum-deriver Example 1: Enum Deriver}
+{{:https://github.com/ocaml-ppx/ppxlib/tree/main/examples/2-Writing-PPXs/a%20-%20Context-Free/context_free.ml#L51-L125} 🔗 Sample Code}
+
+The following example is more complex. Take your time; it’s explained step by step.
+
+Let's say we want to add [to_string] and [from_string] functions to a simple variant type:
+
+{[
+type t = A | B [@@deriving enum]
+(* Output:
+type t = A | B
+let to_string = function
+  | A -> "A"
+  | B -> "B"
+let from_string = function
+  | "A" -> A
+  | "B" -> B
+  | _ -> raise (Invalid_argument "Argument doesn't match t variants")
+*)
+]}
+
+{3 Steps to Implement This Deriver}
+
+- {b Declare the deriver name:}
+
+  {[
+  let deriver_name = "enum"
+  ]}
+
+- {b Define the arguments for the deriver:}
+  For this example, we don't have any arguments:
+
+  {[
+  let args () = Deriving.Args.(empty)
+  ]}
+
+- {b Build the new AST:}
+  We'll match the AST we want to transform and generate the [to_string] and [from_string] functions.
+
+  - {b Match the type declaration with pattern matching:}
+
+    {[
+    let enum ~ctxt ast =
+       let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+       match ast with
+       | ( _,
+           [
+             {
+               ptype_name = { txt = type_name; _ };
+               ptype_kind = Ptype_variant variants;
+               _;
+             };
+           ] ) -> (*...*)
+    ]}
+
+  - {b Create functions to generate the patterns:}
+    All we are going to do here is what we covered in {%html:<a href="../../1%20-%20AST/a%20-%20Building%20AST/README.md">Building AST</a>%}. So it shouldn't be a problem to understand this part.
+
+    - {b Creating the [to_string] function:}
+
+      {[
+      let function_name suffix = type_name ^ suffix in
+      let arg_pattern = [%pat? value] in
+      let function_name_pattern =
+        [%pat? [%p ppat_var ~loc { txt = function_name "_to_string"; loc }]]
+      in
+      let to_string_expr =
+        [%stri
+          let [%p function_name_pattern] =
+          fun [%p arg_pattern] ->
+            [%e
+              pexp_match ~loc [%expr value]
+                (List.map
+                  (fun { pcd_name = { txt = value; _ }; _ } ->
+                    case
+                      ~lhs:
+                        (ppat_construct ~loc (Located.lident ~loc value) None)
+                      ~guard:None ~rhs:(expr_string value))
+                variants)]]
+      ]}
+
+    - {b Build the [from_string] function:}
+
+      {[
+      let else_case =
+        case
+          ~lhs:[%pat? [%p ppat_any ~loc]]
+          ~guard:None
+          ~rhs:
+            [%expr raise (Invalid_argument "Argument doesn't match variants")]
+      in
+      let from_string_expr =
+        [%stri
+          let [%p function_name_pattern] =
+          fun [%p arg_pattern] ->
+            [%e
+              pexp_match ~loc [%expr value]
+                (List.map
+                  (fun { pcd_name = { txt = value; _ }; _ } ->
+                    case
+                      ~lhs:
+                        (ppat_constant ~loc (Pconst_string (value, loc, None)))
+                      ~guard:None ~rhs:
+                        (pexp_construct ~loc (Located.lident ~loc value) None))
+                  variants
+                @ [ else_case ])]]
+      ]}
+
+    - {b Combine and return the functions:}
+
+      {[
+      let enum ~ctxt ast =
+        let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+        match ast with
+        | ( _,
+            [
+              {
+                ptype_name = { txt = type_name; _ };
+                ptype_kind = Ptype_variant variants;
+                _;
+              };
+            ] ) ->
+            let function_name suffix = type_name ^ suffix in
+            let arg_pattern = [%pat? value] in
+            let expr_string = Ast_builder.Default.estring ~loc in
+            let function_name_pattern =
+              [%pat? [%p ppat_var ~loc { txt = function_name "_to_string"; loc }]]
+            in
+            let to_string_expr =
+              [%stri
+                let [%p function_name_pattern] =
+                fun [%p arg_pattern] ->
+                  [%e
+                    pexp_match ~loc [%expr value]
+                      (List.map
+                        (fun { pcd_name = { txt = value; _ }; _ } ->
+                          case
+                            ~lhs:
+                              (ppat_construct ~loc (Located.lident ~loc value) None)
+                            ~guard:None ~rhs:(expr_string value))
+                        variants)]]
+            in
+            (* Uncomment to see the generated code *)
+            (* print_endline (Astlib.Pprintast.string_of_structure [ to_string_expr ]); *)
+            let else_case =
+              case
+                ~lhs:[%pat? [%p ppat_any ~loc]]
+                ~guard:None
+                ~rhs:
+                  [%expr
+                    [%e
+                      pexp_apply ~loc
+                        [%expr
+                          raise
+                            (Invalid_argument
+                              [%e
+                                estring ~loc
+                                  ("Argument doesn't match " ^ type_name
+                                  ^ " variants")])]
+                        []]]
+            in
+            let function_name_pattern =
+              [%pat? [%p ppat_var ~loc { txt = function_name "_from_string"; loc }]]
+            in
+            let from_string_expr =
+              [%stri
+                let [%p function_name_pattern] =
+                fun [%p arg_pattern] ->
+                  [%e
+                    pexp_match ~loc [%expr value]
+                      (List.map
+                        (fun { pcd_name = { txt = value; _ }; _ } ->
+                          case
+                            ~lhs:
+                              (ppat_constant ~loc (Pconst_string (value, loc, None)))
+                            ~guard:None ~rhs:
+                              (pexp_construct ~loc (Located.lident ~loc value) None))
+                        variants
+                      @ [ else_case ])]]
+            in
+            (* Uncomment to see the generated code *)
+            (* print_endline (Astlib.Pprintast.string_of_structure [ from_string_expr ]); *)
+            [ from_string_expr; to_string_expr ]
+        | _ ->
+            [%str
+              [%ocaml.error "Ops, enum2 must be a type with variant without args"]]
+      ]}
+
+- {b Declare the deriver:}
+
+  {[
+  let generator () =
+    Deriving.Generator.V2.make (args ()) (fun ~ctxt ->
+        enum ~loc:Expansion_context.Deriver.derived_item_loc ctxt)
+  let _ = Deriving.add deriver_name ~str_type_decl:(generator ())
+  ]}
+
+{2:example-2-enum-deriver-with-args Example 2: Enum Deriver with args}
+{{:https://github.com/ocaml-ppx/ppxlib/tree/main/examples/2-Writing-PPXs/a%20-%20Context-Free/context_free.ml#L126-L216} 🔗 Sample Code}
+
+Let's say we want to add [to_string] and [from_string] functions to a variant type, but we want to have it with options instead of raise:
+
+{[
+type t = A | B [@@deriving enum2 ~opt]
+(* Output:
+type t = A | B
+let to_string = function
+  | A -> "A"
+  | B -> "B"
+let from_string = function
+  | "A" -> Some A
+  | "B" -> Some B
+  | _ -> None
+*)
+]}
+
+{3 Steps to Implement This Deriver}
+
+This is the same as the previous example, but we need to add a new argument to the deriver:
+
+- {b Declare the deriver name and arguments:}
+
+  {[
+  let deriver_name = "enum"
+  let args () = Deriving.Args.(empty +> arg "opt" bool)
+  ]}
+
+- {b Build the new AST:}
+  There will no much difference on the enum code, we just need to check if the [opt] argument is [true] and add the [option] return to the [from_string] function and change the else to [None]:
+
+  {[
+  let else_case =
+    case
+      ~lhs:[%pat? [%p ppat_any ~loc]]
+      ~guard:None
+      ~rhs:
+        (match opt with
+        | true -> [%expr None]
+        | _ ->
+            [%expr
+              raise (Invalid_argument "Argument doesn't match variants")])
+  in
+  let function_name_pattern =
+    [%pat? [%p ppat_var ~loc { txt = function_name "_from_string"; loc }]]
+  in
+  let from_string_expr =
+    [%stri
+      let [%p function_name_pattern] =
+        fun [%p arg_pattern] ->
+        [%e
+          pexp_match ~loc [%expr value]
+            (List.map
+                (fun { pcd_name = { txt = value; _ }; _ } ->
+                  case
+                    ~lhs:
+                      (ppat_constant ~loc (Pconst_string (value, loc, None)))
+                    ~guard:None
+                    ~rhs:
+                      (match opt with
+                      | true ->
+                          [%expr
+                            Some
+                              [%e
+                                pexp_construct ~loc
+                                  (Located.lident ~loc value)
+                                  None]]
+                      | _ ->
+                          pexp_construct ~loc
+                            (Located.lident ~loc value)
+                            None))
+                variants
+            @ [ else_case ])]]
+  ]}
+
+{1:conclusion Conclusion}
+
+Context-free transformations are a powerful tool in OCaml for modifying code locally. By understanding how to implement extenders and derivers, you can enhance your code generation capabilities and simplify repetitive tasks. With the examples provided, you should have a solid foundation for creating your own context-free transformations using PPXLib.
+
+{2 Next Steps}
+On the next section, we will learn more about global transformations. {{!page-"example-writing-ppxs-global"} Read more}

--- a/doc/example-writing-ppxs-global.mld
+++ b/doc/example-writing-ppxs-global.mld
@@ -1,0 +1,276 @@
+{0 Global Transformations}
+
+{1:table-of-contents Table of Contents}
+
+- {{!section-description} Description}
+- {{!section-"types-of-global-transformations"} Types of Global Transformations}
+- {{!section-"using-ast_traverse"} Using {!Ppxlib.Ast_traverse}}
+{ul {- {{!section-"how-it-works"} How It Works}}}
+{ul {- {{!section-"key-points"} Key Points}}}
+
+- {{!section-"lint"} Lint}
+{ul {- {{!section-"example-1-linting-variable-names-to-have-the-prefix-demo_"} Example 1: Linting Variable Names to Have the Prefix [demo_]}}}
+
+- {{!section-"preprocess"} Preprocess}
+{ul {- {{!section-"example-1-extending-a-module-with-the-enum-attribute"} Example 1: Extending a Module with the [[@enum]] Attribute}}}
+
+- {{!section-"global-transformation"} Global Transformation}
+{ul {- {{!section-"example-1-extending-a-module-with-the-enum2-opt-attribute"} Example 1: Extending a Module with the [[@enum2 opt]] Attribute}}}
+
+- {{!section-conclusion} Conclusion}
+
+{1:description Description}
+
+As we saw in the {{!page-"example-writing-ppxs"} Writing PPXs section}, global transformations are a powerful way to automate tasks that affect entire modules or large sections of code. By extending the principles of context-free transformations to operate at the module level, you can implement transformations that significantly reduce boilerplate and improve code consistency.
+
+{1:types-of-global-transformations Types of Global Transformations}
+
+- {b Lint}
+- {b Preprocess}
+- {b Instrumentation - Before}
+- {b Global Transformation}
+- {b Instrumentation - After}
+
+For now, in this section, we are going to focus on {b Lint}, {b Preprocess}, and {b Global Transformation} because they are the most common phases to register a global transformation. In the future, we plan to add {b Instrumentation - Before} and {b Instrumentation - After}.
+
+{1:using-ast_traverse Using {!Ppxlib.Ast_traverse}}
+
+To help with global transformations, we'll use the {!Ppxlib.Ast_traverse} module from PPXLib in all examples. {!Ppxlib.Ast_traverse} makes it easier to walk through and change the AST in a structured way.
+
+{2:how-it-works How It Works}
+
+{!Ppxlib.Ast_traverse} is helpful for navigating and modifying complex structures like the AST.
+
+Here are the main types of traversals you can do with {!Ppxlib.Ast_traverse}:
+
+- {b Iterators}: Go through the AST and perform actions on each node, often for side effects like checking for specific patterns or enforcing rules.
+
+- {b Maps}: Traverse the AST and replace nodes where needed. This is useful for making changes to the AST and returning a modified version.
+
+- {b Folds}: Traverse the AST while keeping track of some data (an accumulator) that gets updated at each node, such as counting nodes or gathering specific information.
+
+- {b Lifts}: Transform an AST node into a different type by working from the bottom up, often used to convert AST structures into other forms.
+
+{2:key-points Key Points}
+
+- {b Inherit from {!Ppxlib.Ast_traverse} classes}: Depending on your needs, you can inherit from classes like [Ast_traverse.iter] for iterators or [Ast_traverse.map] for maps. This gives you a base to start from.
+
+- {b Override specific methods}: Customize your traversal by overriding methods that handle specific AST nodes, like [module_binding] or [structure_item].
+
+- {b Register with [Driver.register_transformation]}: After defining your traversal, register it with the PPX driver. This ensures your transformations are applied during compilation.
+
+Using {!Ppxlib.Ast_traverse} simplifies global transformations, letting you efficiently modify large sections of code or entire modules without needing to handle all the details manually.
+
+{1:lint Lint}
+
+Linting is a form of static analysis that checks code for potential errors, bugs, or style issues. PPXLib provides a mechanism to implement linting rules using PPX. It takes as input the whole AST and outputs a list of "lint" errors. For linting, we are going to use the [Ast_traverse.fold] as we want to provide a list of errors.
+
+{2:example-1-linting-variable-names-to-have-the-prefix-demo_ Example 1: Linting Variable Names to Have the Prefix [demo_]}
+{{:https://github.com/ocaml-ppx/ppxlib/tree/main/examples/2-Writing-PPXs/b%20-%20Global/global_transformation.ml#L1-L4} 🔗 Sample Code}
+
+Let's create a linting rule that ensures that all [value_binding]s have the prefix [demo_].
+
+{3 Consider the following example}
+
+{[
+(* This will raise a lint error *)
+let name = "John Doe"
+
+(* This will not raise a lint error *)
+let demo_name = "John Doe"
+]}
+
+{3 Steps to Implement This Transformation}
+
+- {b Understand the AST Structure:}
+  We want to match all [value_binding]s. To do this, it’s helpful to see the structure of the AST for a [value_binding]. For that, you can use {{:https://astexplorer.net/#/gist/d479d32127d6fcb418622ee84b9aa3b2/27d0a140f268bae1a32c8882d55c0b26c7e03fe9} AST Explorer}. If you’re not familiar with reading ASTs, check out the {{!page-"example-ast"} AST section}.
+
+- {b Ast_traverse.fold:}
+  We are going to use [Ast_traverse.fold] to provide a list of errors. Since we want to match all [value_binding] names, we’ll override the [value_binding] method in the AST traversal object, and for each [value_binding], we’ll check if the variable name starts with [demo_] using [value_binding.pvb_pat.ppat_desc].
+
+  {[
+  let traverse =
+  object
+    (* Inherit from Ast_traverse.fold with the Lint_error.t list as the accumulator *)
+    inherit [Driver.Lint_error.t list] Ast_traverse.fold
+
+    (* Override the value_binding method to lint the variable name *)
+    (* the value_binding method is called for each value_binding in the AST *)
+    method! value_binding vb acc =
+      let loc = vb.pvb_loc in
+        match ast with
+        (* Match all pattern variables and get their names *)
+        | Ppat_var { txt = name; _ } ->
+            (* Check if the variable name starts with demo_ *)
+            if String.starts_with name ~prefix:"demo_" then acc
+            else
+              (* If not, add a lint error to the accumulator *)
+              Driver.Lint_error.of_string loc
+                "Oops, variable names must start with demo_"
+              :: acc
+        | _ -> acc
+  end
+  ]}
+
+- {b Register the Lint Rule with the PPX Driver:}
+  Register with [~lint_impl].
+
+  {[
+  let _ = Driver.register_transformation "lint" ~lint_impl:traverse#structure
+  ]}
+
+{1:preprocess Preprocess}
+
+Preprocessing is the first phase that alters the AST.
+
+{%html:
+  <div style="border-left: 4px solid #f39c12; padding: 0.2em 1em;">
+    <strong>⚠️ Warning</strong>
+    <p style="margin-top: 0.5em; margin-bottom: 0;">You should only register a transformation in this phase if it is really necessary. You can use the Global Transformation phase instead.</p>
+  </div>
+%}
+
+{2:example-1-extending-a-module-with-the-enum-attribute Example 1: Extending a Module with the [[@enum]] Attribute}
+{{:./context_free.ml#L9-L18} 🔗 Sample Code}
+
+Let’s say we want to extend a module with automatically generated [to_string] and [from_string] functions based on a variant type using the [[@enum]] attribute.
+
+{3 Consider the following example}
+
+{[
+module GameEnum = struct
+  type t = Rock | Paper | Scissors
+end [@enum]
+(* Output:
+module GameEnum = struct
+  type t = Rock | Paper | Scissors
+  let to_string = function
+    | Rock -> "Rock"
+    | Paper -> "Paper"
+    | Scissors -> "Scissors"
+  let from_string = function
+    | "Rock" -> Rock
+    | "Paper" -> Paper
+    | "Scissors" -> Scissors
+    | _ -> failwith "Invalid string"
+end *)
+]}
+
+{3 Steps to Implement This Global Transformation}
+
+- {b Understand the AST Structure:}
+  We want to match a [module_expr] with the [[@enum]] attribute and generate [to_string] and [from_string] functions based on the variant type within the module.
+
+- {b Ast_traverse.map:}
+  We are going to use [Ast_traverse.map] because we want to modify the AST. We’ll override the [module_expr] method in the AST traversal object to append the generated [to_string] and [from_string] functions to the module's structure.
+
+  {[
+  let traverse =
+    object
+      inherit Ast_traverse.map as super
+
+      (* Override the module_expr method to generate to_string and from_string functions *)
+      method! module_expr mod_exp =
+        (* Call the super method to traverse the module expression *)
+        let mod_exp = super#module_expr mod_exp in
+        (* Check if the module expression has the [@enum] attribute *)
+        match mod_exp.pmod_attributes with
+        | [ { attr_name = { txt = "enum"; _ }; _ } ]
+          -> (
+            (* match the module expression structure to get the type name and variants *)
+            match mod_exp.pmod_desc with
+            | Pmod_structure
+                ([ { pstr_desc = Pstr_type (name, variants); _ } ] as str) ->
+                (* We are not going to show the enum function because we already covered it in the previous Context-free section *)
+                let type_ =
+                  enum ~loc:mod_exp.pmod_loc (name, variants) ()
+                in
+                (* Append the generated functions to the module structure *)
+                Ast_builder.Default.pmod_structure ~loc:mod_exp.pmod_loc (str @ type_)
+            | _ -> mod_exp)
+        | _ -> mod_exp
+    end
+  ]}
+
+- {b Register the Deriver with the PPX Driver:}
+
+  {[
+  let _ = Driver.register_transformation "enum" ~impl:traverse#structure
+  ]}
+
+{1:global-transformation Global Transformation}
+
+The Global Transformation phase can be confusing because everything we’ve discussed in this section falls under global transformations. However, the Global Transformation phase specifically refers to the phase that happens after the Context-free phase.
+
+This is the most common phase to register a global transformation that alters the AST.
+
+The API of the global transformation is the same as the preprocess, and to make it simple, we are going to use the same example as the preprocess, but with payload.
+
+{2:example-1-extending-a-module-with-the-enum2-opt-attribute Example 1: Extending a Module with the [[@enum2 opt]] Attribute}
+{{:https://github.com/ocaml-ppx/ppxlib/tree/main/examples/2-Writing-PPXs/b%20-%20Global/global_transformation.ml#L27-L47} 🔗 Sample Code}
+
+Let’s extend the previous example to add support for an [opt] argument that modifies the behavior of the [from_string] function to return an [option] type instead of raising an exception.
+
+{3 Consider the following example}
+
+{[
+module GameEnum2 = struct
+  type t = Rock | Paper | Scissors
+end [@enum2 opt]
+(* Output:
+module GameEnum2 = struct
+  type t = Rock | Paper | Scissors
+  let to_string = function
+    | Rock -> "Rock"
+    | Paper -> "Paper"
+    | Scissors -> "Scissors"
+  let from_string = function
+    | "Rock" -> Some Rock
+    | "Paper" -> Some Paper
+    | "Scissors" -> Some Scissors
+    | _ -> None
+end *)
+]}
+
+{3 Steps to Implement This Global Transformation}
+
+- {b This example is an extension of the previous one.}
+  The only thing that changes is the [from_string] function, which now returns an [option] type instead of raising an exception. To do this, we need to get the attribute's payload.
+
+  {[
+  (* Check if the module expression has the @enum2 attribute and get the attribute's payload *)
+  | [ { attr_name = { txt = "enum2"; _ }; attr_payload = payload; _ } ]
+          -> (
+            (* match the module expression structure to get the type name and variants *)
+            let opt =
+              match payload with PStr [%str opt] -> true | _ -> false
+            in
+            match mod_exp.pmod_desc with
+            | Pmod_structure
+                ([ { pstr_desc = Pstr_type (name, variants); _ } ] as str) ->
+                (* We are not going to show the enum function because we already covered it in the previous Context-free section *)
+                let type_ =
+                  enum ~loc:mod_exp.pmod_loc ~opt (name, variants) ()
+                in
+                Ast_builder.Default.pmod_structure ~loc:mod_exp.pmod_loc (str @ type_)
+            | _ -> mod_exp)
+        | _ -> mod_exp
+  ]}
+
+- {b Register the Deriver with the PPX Driver:}
+  The difference here compared to the preprocess is that we are going to use the [~impl] instead of [~preprocess_impl].
+
+  {[
+  let _ = Driver.register_transformation "enum2" ~impl:traverse#structure
+  ]}
+
+{1:conclusion Conclusion}
+
+Global transformations in OCaml using PPXLib allow you to automate repetitive tasks and enforce coding patterns across your entire codebase. By using phases like {b Preprocess}, {b Global Transformation}, and {b Lint}, you can reduce boilerplate code, maintain consistency, and catch potential issues early.
+
+We looked at how {!Ppxlib.Ast_traverse} helps in navigating and modifying the AST for tasks like generating [to_string] and [from_string] functions or implementing linting rules. The examples showed how to extend modules with attributes like [[@enum]] and [[@enum2 opt]].
+
+Understanding these concepts and using the right transformation phase ensures your code is cleaner, more consistent, and easier to maintain.
+
+{2 Next Steps}
+On the next section, we will explore advanced use cases of global transformations. {{!page-"example-writing-ppxs-global"} Read more}

--- a/doc/example-writing-ppxs.mld
+++ b/doc/example-writing-ppxs.mld
@@ -1,0 +1,57 @@
+{0 Writing PPXs}
+
+{1:table-of-contents Table of Contents}
+
+- {{!section-description} Description}
+- {{!section-transformations} Transformations}
+- {{!section-how} How}
+- {{!section-"next-steps"} Next Steps}
+
+{1:description Description}
+
+After knowing what is an {{!page-"example-ast"} AST}, how to {{!page-"example-ast-building"} build an AST} and {{!page-"example-ast-destructing"} destructure it}, we can now write our own PPX in OCaml.
+
+{1:transformations Transformations}
+
+The soul of a PPX is the transformation. We want to get our AST and transform it into something else, like a new AST or lint errors.
+
+Those transformations can be divided into two categories that we will cover on nested folders:
+
+- {{!page-"example-writing-ppxs-context-free"} Context-free transformations}
+- {{!page-"example-writing-ppxs-global"} Global transformations}
+
+And they can work in different phases:
+
+- Lint (Global)
+- Preprocess (Global)
+- Instrumentation - Before (Global)
+- Context-free
+- Global Transformation (Global)
+- Instrumentation - After (Global)
+
+The following diagram shows the order of the phases and Driver's methods:
+
+{%html:
+<figure>
+  <img
+  style="width: 100%;"
+  src="./assets/images/ppxlib-phases.png"
+  alt="The beautiful MDN logo.">
+  <small><figcaption>Driver's methods phases diagram.<a href="https://x.com/_anmonteiro/status/1644031054544789504"> (reference)</a></figcaption></small>
+</figure>
+%}
+
+{1:how How}
+
+PPXs commonly follow these steps:
+
+- Match the AST we want.
+- Work with the AST. For example:
+{ul {- Returning a new AST. Add new functions, change the name of a variable, etc.}
+{- Linting the code.}
+{- or doing anything else. Really, you're programming, everything is possible!}
+}
+
+{1:next-steps Next Steps}
+
+On the next section, we will learn more about Context Free transformations. {{!page-"example-writing-ppxs-context-free"} Read more}

--- a/examples/2-Writing-PPXs/a - Context Free/README.md
+++ b/examples/2-Writing-PPXs/a - Context Free/README.md
@@ -1,0 +1,9 @@
+# Context-Free Transformations
+
+Checkout the [Examples - Context-Free Transformations](https://ocaml-ppx.github.io/ppxlib/examples-context-free-transformations.html) for more information
+
+To run this example:
+
+```sh
+make example-context-free
+```

--- a/examples/2-Writing-PPXs/a - Context Free/context_free.ml
+++ b/examples/2-Writing-PPXs/a - Context Free/context_free.ml
@@ -1,0 +1,220 @@
+open Ppxlib
+open Ast_builder.Default
+
+(* PPX Extender *)
+let structure_item ~loc = [%expr 1]
+
+let expand ~ctxt =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+  structure_item ~loc
+
+let my_extension =
+  Extension.V3.declare "one" Extension.Context.expression
+    Ast_pattern.(pstr nil)
+    expand
+
+let rule = Ppxlib.Context_free.Rule.extension my_extension
+let () = Driver.register_transformation ~rules:[ rule ] "one"
+
+(* PPX Extender with payload *)
+type emoji = { emoji : string; alias : string }
+
+let pattern = Ast_pattern.(single_expr_payload (estring __))
+let expression ~loc ~value = [%expr [%e estring ~loc value]]
+
+let emojis =
+  [
+    { emoji = "😀"; alias = "grin" };
+    { emoji = "😃"; alias = "smiley" };
+    { emoji = "😄"; alias = "smile" };
+  ]
+
+let expand ~ctxt emoji_text =
+  let loc = Expansion_context.Extension.extension_point_loc ctxt in
+
+  let find_emoji_by_alias alias =
+    List.find_opt (fun emoji -> alias = emoji.alias) emojis
+  in
+
+  match find_emoji_by_alias emoji_text with
+  | Some value -> expression ~loc ~value:value.emoji
+  | None ->
+      let ext =
+        Location.error_extensionf ~loc "No emoji for %s alias" emoji_text
+      in
+      Ast_builder.Default.pexp_extension ~loc ext
+
+let my_extension =
+  Extension.V3.declare "emoji" Extension.Context.expression pattern expand
+
+(* PPX Deriver *)
+let rule = Ppxlib.Context_free.Rule.extension my_extension
+let () = Driver.register_transformation ~rules:[ rule ] "emoji"
+let args () = Deriving.Args.(empty)
+
+(* add to_string and from_string helpers to a type variant *)
+let enum ~ctxt ast =
+  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+  match ast with
+  | ( _,
+      [
+        {
+          ptype_name = { txt = type_name; _ };
+          ptype_kind = Ptype_variant variants;
+          _;
+        };
+      ] ) ->
+      let function_name suffix = type_name ^ suffix in
+      let arg_pattern = [%pat? value] in
+      let expr_string = Ast_builder.Default.estring ~loc in
+      let function_name_pattern =
+        [%pat? [%p ppat_var ~loc { txt = function_name "_to_string"; loc }]]
+      in
+      let to_string_expr =
+        [%stri
+          let[@warning "-32"] [%p function_name_pattern] =
+           fun [%p arg_pattern] ->
+            [%e
+              pexp_match ~loc [%expr value]
+                (List.map
+                   (fun { pcd_name = { txt = value; _ }; _ } ->
+                     case
+                       ~lhs:
+                         (ppat_construct ~loc (Located.lident ~loc value) None)
+                       ~guard:None ~rhs:(expr_string value))
+                   variants)]]
+      in
+      (* Uncomment to see the generated code *)
+      (* print_endline (Astlib.Pprintast.string_of_structure [ to_string_expr ]); *)
+      let else_case =
+        case
+          ~lhs:[%pat? [%p ppat_any ~loc]]
+          ~guard:None
+          ~rhs:
+            [%expr raise (Invalid_argument "Argument doesn't match variants")]
+      in
+      let function_name_pattern =
+        [%pat? [%p ppat_var ~loc { txt = function_name "_from_string"; loc }]]
+      in
+      let from_string_expr =
+        [%stri
+          let[@warning "-32"] [%p function_name_pattern] =
+           fun [%p arg_pattern] ->
+            [%e
+              pexp_match ~loc [%expr value]
+                (List.map
+                   (fun { pcd_name = { txt = value; _ }; _ } ->
+                     case
+                       ~lhs:
+                         (ppat_constant ~loc
+                            (Ast_helper.Const.mk ~loc
+                            @@ Pconst_string (value, loc, None)))
+                       ~guard:None
+                       ~rhs:
+                         (pexp_construct ~loc (Located.lident ~loc value) None))
+                   variants
+                @ [ else_case ])]]
+      in
+      (* Uncomment to see the generated code *)
+      (* print_endline (Astlib.Pprintast.string_of_structure [ from_string_expr ]); *)
+      [ from_string_expr; to_string_expr ]
+  | _ ->
+      [%str
+        [%ocaml.error "Ops, enum2 must be a type with variant without args"]]
+
+let generator () = Deriving.Generator.V2.make (args ()) enum
+let _ = Deriving.add "enum" ~str_type_decl:(generator ())
+let args () = Deriving.Args.(empty +> flag "opt")
+
+let enum_opt ~ctxt ast opt =
+  let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+  match ast with
+  | ( _,
+      [
+        {
+          ptype_name = { txt = type_name; _ };
+          ptype_kind = Ptype_variant variants;
+          _;
+        };
+      ] ) ->
+      let function_name suffix = type_name ^ suffix in
+      let expr_string = Ast_builder.Default.estring ~loc in
+      let arg_pattern = [%pat? value] in
+      let function_name_pattern =
+        [%pat? [%p ppat_var ~loc { txt = function_name "_to_string"; loc }]]
+      in
+      let to_string_expr =
+        [%stri
+          let[@warning "-32"] [%p function_name_pattern] =
+           fun [%p arg_pattern] ->
+            [%e
+              pexp_match ~loc [%expr value]
+                (List.fold_left
+                   (fun acc { pcd_name = { txt = value; _ }; _ } ->
+                     acc
+                     @ [
+                         case
+                           ~lhs:
+                             (ppat_construct ~loc
+                                (Located.lident ~loc value)
+                                None)
+                           ~guard:None ~rhs:(expr_string value);
+                       ])
+                   [] variants)]]
+      in
+
+      (* Uncomment to see the generated code *)
+      (* print_endline (Astlib.Pprintast.string_of_structure [ to_string_expr ]); *)
+      let else_case =
+        case
+          ~lhs:[%pat? [%p ppat_any ~loc]]
+          ~guard:None
+          ~rhs:
+            (match opt with
+            | true -> [%expr None]
+            | _ ->
+                [%expr
+                  raise (Invalid_argument "Argument doesn't match variants")])
+      in
+      let function_name_pattern =
+        [%pat? [%p ppat_var ~loc { txt = function_name "_from_string"; loc }]]
+      in
+      let from_string_expr =
+        [%stri
+          let[@warning "-32"] [%p function_name_pattern] =
+           fun [%p arg_pattern] ->
+            [%e
+              pexp_match ~loc [%expr value]
+                (List.map
+                   (fun { pcd_name = { txt = value; _ }; _ } ->
+                     case
+                       ~lhs:
+                         (ppat_constant ~loc
+                            (Ast_helper.Const.mk ~loc
+                            @@ Pconst_string (value, loc, None)))
+                       ~guard:None
+                       ~rhs:
+                         (match opt with
+                         | true ->
+                             [%expr
+                               Some
+                                 [%e
+                                   pexp_construct ~loc
+                                     (Located.lident ~loc value)
+                                     None]]
+                         | _ ->
+                             pexp_construct ~loc
+                               (Located.lident ~loc value)
+                               None))
+                   variants
+                @ [ else_case ])]]
+      in
+      (* Uncomment to see the generated code *)
+      (* print_endline (Astlib.Pprintast.string_of_structure [ from_string_expr ]); *)
+      [ from_string_expr; to_string_expr ]
+  | _ ->
+      [%str
+        [%ocaml.error "Ops, enum with opt must be a type with variant without args"]]
+
+let generator () = Deriving.Generator.V2.make (args ()) enum_opt
+let _ = Deriving.add "enum_opt" ~str_type_decl:(generator ())

--- a/examples/2-Writing-PPXs/a - Context Free/demo/context_free_example.ml
+++ b/examples/2-Writing-PPXs/a - Context Free/demo/context_free_example.ml
@@ -1,0 +1,43 @@
+let one = [%one]
+let _ = Printf.printf "One: %d\n" one
+let grin = [%emoji "grin"]
+let smiley = [%emoji "smiley"]
+let _ = print_endline ("grin: " ^ grin)
+let _ = print_endline ("smiley: " ^ smiley)
+
+(* enum with raise *)
+let _ = print_endline "\n# Enum with raise"
+
+type game = Rock | Paper | Scissors [@@deriving enum]
+
+let _ = Printf.printf "Rock to string: %s\n" (game_to_string Rock)
+
+let _ =
+  Printf.printf "Paper to string: %s\n"
+    (game_to_string (game_from_string "Paper"))
+
+let _ =
+  try
+    Printf.printf "Stick to string: %s\n"
+      (game_to_string (game_from_string "Stick"))
+  with _ -> Printf.printf "Stick is not a valid value\n"
+
+(* enum with option *)
+let _ = print_endline "\n# Enum with option"
+
+type game2 = Rock | Paper | Scissors [@@deriving enum2 ~opt]
+
+let _ = Printf.printf "Rock to string: %s\n" (game2_to_string Rock)
+
+let _ =
+  match game2_from_string "Paper" with
+  | Some value -> Printf.printf "Paper to string: %s\n" (game2_to_string value)
+  | None -> Printf.printf "Paper is not a valid value\n"
+
+let _ =
+  match game2_from_string "Stick" with
+  | Some value -> Printf.printf "Stick to string: %s\n" (game2_to_string value)
+  | None -> Printf.printf "Stick is not a valid value\n"
+
+(* Uncomment the code bellow to see the error *)
+(* type bar = string [@@deriving enum2] *)

--- a/examples/2-Writing-PPXs/a - Context Free/demo/dune
+++ b/examples/2-Writing-PPXs/a - Context Free/demo/dune
@@ -1,0 +1,6 @@
+(executable
+ (name context_free_example)
+ (package ppxlib)
+ (public_name context-free-example)
+ (preprocess
+  (pps context_free)))

--- a/examples/2-Writing-PPXs/a - Context Free/dune
+++ b/examples/2-Writing-PPXs/a - Context Free/dune
@@ -1,0 +1,7 @@
+(library
+ (name context_free)
+ (kind ppx_rewriter)
+ (package ppxlib)
+ (libraries ppxlib yojson ppxlib.astlib)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/examples/2-Writing-PPXs/b - Global/README.md
+++ b/examples/2-Writing-PPXs/b - Global/README.md
@@ -1,0 +1,9 @@
+# Global Transformations
+
+Checkout the [Examples - Global Transformations](https://ocaml-ppx.github.io/ppxlib/examples-global-transformations.html) for more information
+
+To run this example:
+
+```sh
+make example-global
+```

--- a/examples/2-Writing-PPXs/b - Global/demo/dune
+++ b/examples/2-Writing-PPXs/b - Global/demo/dune
@@ -1,0 +1,6 @@
+(executable
+ (name global_transformation_example)
+ (public_name global-transformation-example)
+ (package ppxlib)
+ (preprocess
+  (pps global_transformation)))

--- a/examples/2-Writing-PPXs/b - Global/demo/global_transformation_example.ml
+++ b/examples/2-Writing-PPXs/b - Global/demo/global_transformation_example.ml
@@ -1,0 +1,51 @@
+let demo_name = "Global Demo"
+let _ = demo_name
+
+(* Uncomment the code bellow to see the lint error *)
+(* let name = "John Doe" *)
+
+(* module enum *)
+let _ = print_endline "\n# Enum"
+
+module GameEnum = struct
+  type t = Rock | Paper | Scissors
+end [@enum]
+
+let _ = print_endline (GameEnum.to_string Rock)
+let _ = print_endline (GameEnum.to_string (GameEnum.from_string "Paper"))
+
+let _ =
+  try
+    Printf.printf "Stick to string: %s\n"
+      (GameEnum.to_string (GameEnum.from_string "Stick"))
+  with _ -> Printf.printf "Stick is not a valid value\n"
+
+(* module enum *)
+let _ = print_endline "\n# Enum with option"
+
+module GameEnum2 = struct
+  type t = Rock | Paper | Scissors
+end [@enum2 opt]
+
+let _ = print_endline (GameEnum2.to_string Rock)
+
+let _ =
+  match GameEnum2.from_string "Paper" with
+  | Some value ->
+      Printf.printf "Paper to string: %s\n" (GameEnum2.to_string value)
+  | None -> Printf.printf "Paper is not a valid value\n"
+
+let _ =
+  match GameEnum2.from_string "Stick" with
+  | Some value ->
+      Printf.printf "Stick to string: %s\n" (GameEnum2.to_string value)
+  | None -> Printf.printf "Stick is not a valid value\n"
+
+(* Uncomment the code bellow to see the error *)
+(* module GameEnumError = struct
+     type _t = Rock | Paper | Scissors
+
+     module GameEnum = struct
+       type t = Rock | Paper | Scissors
+     end [@enum]
+   end [@enum] *)

--- a/examples/2-Writing-PPXs/b - Global/dune
+++ b/examples/2-Writing-PPXs/b - Global/dune
@@ -1,0 +1,6 @@
+(library
+ (name global_transformation)
+ (kind ppx_rewriter)
+ (libraries context_free ppxlib ppxlib.astlib)
+ (preprocess
+  (pps ppxlib.metaquot)))

--- a/examples/2-Writing-PPXs/b - Global/global_transformation.ml
+++ b/examples/2-Writing-PPXs/b - Global/global_transformation.ml
@@ -1,0 +1,139 @@
+open Ppxlib
+open Ast_builder.Default
+
+let enum_tag = "enum"
+
+(* This function is well explained in the Context Free Section *)
+let enum ~loc ?(opt = false) ast () =
+  match ast with
+  | _, [ { ptype_kind = Ptype_variant variants; _ } ] ->
+      let expr_string = Ast_builder.Default.estring ~loc in
+      let to_string_expr =
+        [%stri
+          let[@warning "-32"] to_string value =
+            [%e
+              pexp_match ~loc [%expr value]
+                (List.map
+                   (fun { pcd_name = { txt = value; _ }; _ } ->
+                     case
+                       ~lhs:
+                         (ppat_construct ~loc (Located.lident ~loc value) None)
+                       ~guard:None ~rhs:(expr_string value))
+                   variants)]]
+      in
+      let else_case =
+        case
+          ~lhs:[%pat? [%p ppat_any ~loc]]
+          ~guard:None
+          ~rhs:
+            (match opt with
+            | true -> [%expr None]
+            | _ ->
+                [%expr
+                  raise (Invalid_argument "Argument doesn't match variants")])
+      in
+      let from_string_expr =
+        [%stri
+          let[@warning "-32"] from_string value =
+            [%e
+              pexp_match ~loc [%expr value]
+                (List.map
+                   (fun { pcd_name = { txt = value; _ }; _ } ->
+                     case
+                       ~lhs:
+                         (ppat_constant ~loc
+                            (Ast_helper.Const.mk ~loc
+                            @@ Pconst_string (value, loc, None)))
+                       ~guard:None
+                       ~rhs:
+                         (match opt with
+                         | true ->
+                             [%expr
+                               Some
+                                 [%e
+                                   pexp_construct ~loc
+                                     (Located.lident ~loc value)
+                                     None]]
+                         | _ ->
+                             pexp_construct ~loc
+                               (Located.lident ~loc value)
+                               None))
+                   variants
+                @ [ else_case ])]]
+      in
+      [ from_string_expr; to_string_expr ]
+  | _ ->
+      [%str [%ocaml.error "Ops, enum must be a type with variant without args"]]
+
+module Lint = struct
+  let traverse =
+    object
+      inherit [Driver.Lint_error.t list] Ast_traverse.fold
+
+      method! value_binding mb acc =
+        let loc = mb.pvb_loc in
+        match mb.pvb_pat.ppat_desc with
+        | Ppat_var { txt = name; _ } ->
+            if String.starts_with name ~prefix:"demo_" then acc
+            else
+              Driver.Lint_error.of_string loc
+                "Ops, variable name must not start with demo_"
+              :: acc
+        | _ -> acc
+    end
+end
+
+let _ =
+  Driver.register_transformation "enum2" ~lint_impl:(fun st ->
+      Lint.traverse#structure st [])
+
+module PreProcess = struct
+  let traverse =
+    object (_ : Ast_traverse.map)
+      inherit Ast_traverse.map as super
+
+      method! module_expr mod_exp =
+        let mod_exp = super#module_expr mod_exp in
+        match mod_exp.pmod_attributes with
+        | [ { attr_name = { txt = "enum"; _ }; _ } ] -> (
+            match mod_exp.pmod_desc with
+            | Pmod_structure
+                ([ { pstr_desc = Pstr_type (name, variants); _ } ] as str) ->
+                let type_ = enum ~loc:mod_exp.pmod_loc (name, variants) () in
+                Ast_builder.Default.pmod_structure ~loc:mod_exp.pmod_loc
+                  (str @ type_)
+            | _ -> mod_exp)
+        | _ -> mod_exp
+    end
+end
+
+let _ =
+  Driver.register_transformation "enum" ~impl:PreProcess.traverse#structure
+
+module Global = struct
+  let traverse =
+    object (_ : Ast_traverse.map)
+      inherit Ast_traverse.map as super
+
+      method! module_expr mod_exp =
+        let mod_exp = super#module_expr mod_exp in
+        match mod_exp.pmod_attributes with
+        | [ { attr_name = { txt = "enum2"; _ }; attr_payload = payload; _ } ]
+          -> (
+            let opt =
+              match payload with PStr [%str opt] -> true | _ -> false
+            in
+            match mod_exp.pmod_desc with
+            | Pmod_structure
+                ([ { pstr_desc = Pstr_type (name, variants); _ } ] as str) ->
+                let type_ =
+                  enum ~loc:mod_exp.pmod_loc ~opt (name, variants) ()
+                in
+                Ast_builder.Default.pmod_structure ~loc:mod_exp.pmod_loc
+                  (str @ type_)
+            | _ -> mod_exp)
+        | _ -> mod_exp
+    end
+end
+
+let _ = Driver.register_transformation "enum2" ~impl:Global.traverse#structure


### PR DESCRIPTION
## Description

I'm dividing the examples into multiple PRs so we can review them better, focusing on the explanation and typos without having many files to review. It is necessary that this section is easy to understand and is aligned with ppxlib.

## Writing PPX's

This PR adds the Writing PPXs sections Writing PPXs / Global Transformations / Context-Free Transformations

## How to test it (It's important to check it not only by code but also as styles)

- At this branch run 
  ```bash
   make doc
   open _build/default/_doc/_html/ppxlib/index.html
  ```
- Access [Examples](file:///Users/pedrolisboa/study/ppxlib/_build/default/_doc/_html/ppxlib/examples.html)
- Access each section: 
  - Writing PPXs
  - Context-Free Transformations
  - Global Transformations